### PR TITLE
Feature: タスクのrepositoryを作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
+        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.1.3"
       }
     },
@@ -3751,6 +3752,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/goober": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
@@ -5397,6 +5405,27 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsx": {
       "version": "4.19.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
@@ -5710,6 +5739,26 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.3"
   }
 }

--- a/src/features/tasks/mocks/handlers.ts
+++ b/src/features/tasks/mocks/handlers.ts
@@ -1,8 +1,9 @@
 import { http, HttpResponse } from 'msw';
+import type { AsyncReturnType } from '@/lib/types';
 import type { TasksRepository } from '../repository';
 import { createMockTask } from '.';
 
-const getAllMockData: Awaited<ReturnType<TasksRepository['getAll']>> = [
+const getAllMockData: AsyncReturnType<TasksRepository['getAll']> = [
   createMockTask(),
   createMockTask({ id: '0002' }),
   createMockTask({ id: '0003' }),

--- a/src/features/tasks/mocks/handlers.ts
+++ b/src/features/tasks/mocks/handlers.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw';
+import type { TasksRepository } from '../repository/types';
+import { createMockTask } from '.';
+
+const getAllMockData: Awaited<ReturnType<TasksRepository['getAll']>> = [
+  createMockTask(),
+  createMockTask({ id: '0002' }),
+  createMockTask({ id: '0003' }),
+  createMockTask({ id: '0004' }),
+];
+
+export const tasksHandlers = [http.get('/api/tasks', () => HttpResponse.json(getAllMockData))];

--- a/src/features/tasks/mocks/handlers.ts
+++ b/src/features/tasks/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import type { TasksRepository } from '../repository/types';
+import type { TasksRepository } from '../repository';
 import { createMockTask } from '.';
 
 const getAllMockData: Awaited<ReturnType<TasksRepository['getAll']>> = [

--- a/src/features/tasks/mocks/index.ts
+++ b/src/features/tasks/mocks/index.ts
@@ -1,0 +1,21 @@
+import type { Task } from '../types';
+
+export function createMockTask({
+  id = '0001',
+  title = 'タスクのタイトル',
+  description = 'タスクの詳細',
+  status = 'completed',
+  createdAt = '2025-05-01T12:00:00.000Z',
+  updatedAt = '2025-05-01T12:00:00.000Z',
+  expiredAt = '2025-06-01T12:00:00.000Z',
+}: Partial<Task> = {}): Task {
+  return {
+    id,
+    title,
+    description,
+    status,
+    createdAt,
+    updatedAt,
+    expiredAt,
+  };
+}

--- a/src/features/tasks/repository/__tests__/tasksRepository.test.ts
+++ b/src/features/tasks/repository/__tests__/tasksRepository.test.ts
@@ -1,6 +1,7 @@
 import type { ApiError } from '@/lib/api-client/types';
 import { createTasksRepository, TasksApiException } from '..';
 import type { TasksRepository } from '../types';
+import { createMockTask } from '../../mocks';
 
 const mockApiClient = {
   get: vi.fn(),
@@ -12,25 +13,15 @@ const mockApiClient = {
 const mockApiErrorStatus = 500;
 const mockApiErrorMessage = 'Internal Server Error';
 const mockApiError: ApiError = {
-    status: mockApiErrorStatus,
-    message: mockApiErrorMessage,
-    error: {}
+  status: mockApiErrorStatus,
+  message: mockApiErrorMessage,
+  error: {},
 };
 
 describe('createTasksRepository', () => {
   describe('getAll', () => {
     it('正常系', async () => {
-      const mockResponse: Awaited<ReturnType<TasksRepository['getAll']>> = [
-        {
-          id: '0001',
-          title: 'タスクのタイトル',
-          description: 'タスクの詳細',
-          status: 'completed',
-          createdAt: '2025-05-01T12:00:00.000Z',
-          updatedAt: '2025-05-01T12:00:00.000Z',
-          expiredAt: '2025-06-01T12:00:00.000Z',
-        },
-      ];
+      const mockResponse: Awaited<ReturnType<TasksRepository['getAll']>> = [createMockTask()];
       mockApiClient.get.mockResolvedValueOnce({ data: mockResponse });
 
       const tasksRepository = createTasksRepository(mockApiClient);

--- a/src/features/tasks/repository/__tests__/tasksRepository.test.ts
+++ b/src/features/tasks/repository/__tests__/tasksRepository.test.ts
@@ -1,4 +1,5 @@
 import type { ApiError } from '@/lib/api-client/types';
+import type { AsyncReturnType } from '@/lib/types';
 import { createMockTask } from '../../mocks';
 import { createTasksRepository, TasksApiException } from '..';
 import type { TasksRepository } from '..';
@@ -21,7 +22,7 @@ const mockApiError: ApiError = {
 describe('createTasksRepository', () => {
   describe('getAll', () => {
     it('正常系', async () => {
-      const mockResponse: Awaited<ReturnType<TasksRepository['getAll']>> = [createMockTask()];
+      const mockResponse: AsyncReturnType<TasksRepository['getAll']> = [createMockTask()];
       mockApiClient.get.mockResolvedValueOnce({ data: mockResponse });
 
       const tasksRepository = createTasksRepository(mockApiClient);

--- a/src/features/tasks/repository/__tests__/tasksRepository.test.ts
+++ b/src/features/tasks/repository/__tests__/tasksRepository.test.ts
@@ -1,7 +1,7 @@
 import type { ApiError } from '@/lib/api-client/types';
-import { createTasksRepository, TasksApiException } from '..';
-import type { TasksRepository } from '../types';
 import { createMockTask } from '../../mocks';
+import { createTasksRepository, TasksApiException } from '..';
+import type { TasksRepository } from '..';
 
 const mockApiClient = {
   get: vi.fn(),

--- a/src/features/tasks/repository/__tests__/tasksRepository.test.ts
+++ b/src/features/tasks/repository/__tests__/tasksRepository.test.ts
@@ -1,0 +1,52 @@
+import type { ApiError } from '@/lib/api-client/types';
+import { createTasksRepository, TasksApiException } from '..';
+import type { TasksRepository } from '../types';
+
+const mockApiClient = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+
+const mockApiErrorStatus = 500;
+const mockApiErrorMessage = 'Internal Server Error';
+const mockApiError: ApiError = {
+    status: mockApiErrorStatus,
+    message: mockApiErrorMessage,
+    error: {}
+};
+
+describe('createTasksRepository', () => {
+  describe('getAll', () => {
+    it('正常系', async () => {
+      const mockResponse: Awaited<ReturnType<TasksRepository['getAll']>> = [
+        {
+          id: '0001',
+          title: 'タスクのタイトル',
+          description: 'タスクの詳細',
+          status: 'completed',
+          createdAt: '2025-05-01T12:00:00.000Z',
+          updatedAt: '2025-05-01T12:00:00.000Z',
+          expiredAt: '2025-06-01T12:00:00.000Z',
+        },
+      ];
+      mockApiClient.get.mockResolvedValueOnce({ data: mockResponse });
+
+      const tasksRepository = createTasksRepository(mockApiClient);
+      const response = await tasksRepository.getAll();
+
+      expect(response).toEqual(mockResponse);
+      // apiClientに渡している引数が正しいかどうか
+      expect(mockApiClient.get).toHaveBeenCalledWith('/api/tasks');
+    });
+    it('異常系', async () => {
+      mockApiClient.get.mockResolvedValue({ error: mockApiError });
+
+      const tasksRepository = createTasksRepository(mockApiClient);
+
+      await expect(tasksRepository.getAll()).rejects.toBeInstanceOf(TasksApiException);
+      await expect(tasksRepository.getAll()).rejects.toThrow('Failed to fetch tasks');
+    });
+  });
+});

--- a/src/features/tasks/repository/index.ts
+++ b/src/features/tasks/repository/index.ts
@@ -1,5 +1,6 @@
-import { apiClient } from '@/lib/api-client';
 import { ApiException } from '@/lib/exceptions/api';
+import type { ApiClient } from '@/lib/api-client/types.ts';
+import type { TasksRepository } from './types.ts';
 
 export class TasksApiException extends ApiException {
   constructor(...args: ConstructorParameters<typeof ApiException>) {
@@ -7,14 +8,16 @@ export class TasksApiException extends ApiException {
   }
 }
 
-export const tasksRepository = {
-  async getTasks() {
-    const response = await apiClient.get('/api/tasks');
+export function createTasksRepository(apiClient: ApiClient): TasksRepository {
+  return {
+    async getAll() {
+      const response = await apiClient.get<ReturnType<TasksRepository['getAll']>>('/api/tasks');
 
-    if (response.error) {
-      throw new TasksApiException('Failed to fetch tasks', response.error);
-    }
+      if (response.error) {
+        throw new TasksApiException('Failed to fetch tasks', response.error);
+      }
 
-    return response.data;
-  },
-};
+      return response.data;
+    },
+  };
+}

--- a/src/features/tasks/repository/index.ts
+++ b/src/features/tasks/repository/index.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '@/lib/api-client';
+import { ApiException } from '@/lib/exceptions/api';
+
+export class TasksApiException extends ApiException {
+  constructor(...args: ConstructorParameters<typeof ApiException>) {
+    super(...args);
+  }
+}
+
+export const tasksRepository = {
+  async getTasks() {
+    const response = await apiClient.get('/api/tasks');
+
+    if (response.error) {
+      throw new TasksApiException('Failed to fetch tasks', response.error);
+    }
+
+    return response.data;
+  },
+};

--- a/src/features/tasks/repository/index.ts
+++ b/src/features/tasks/repository/index.ts
@@ -21,3 +21,5 @@ export function createTasksRepository(apiClient: ApiClient): TasksRepository {
     },
   };
 }
+
+export * from './types.ts';

--- a/src/features/tasks/repository/types.ts
+++ b/src/features/tasks/repository/types.ts
@@ -1,0 +1,5 @@
+import type { Task } from '../types';
+
+export type TasksRepository = {
+  getAll: () => Promise<Task[]>;
+};

--- a/src/lib/exceptions/api.ts
+++ b/src/lib/exceptions/api.ts
@@ -1,0 +1,20 @@
+import type { ApiError } from '@/lib/api-client/types';
+
+/**
+ * 外部APIとの通信時にエラーが発生した場合の例外クラス
+ */
+export class ApiException extends Error {
+  public name: string;
+  public status: ApiError['status'];
+  public originalError: Omit<ApiError['error'], 'status'>;
+
+  constructor(message: string, error: ApiError) {
+    super(message);
+
+    this.name = 'ApiException';
+
+    const { status, ...rest } = error;
+    this.status = status;
+    this.originalError = rest;
+  }
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,3 @@
+export type AsyncReturnType<F extends (...args: unknown[]) => Promise<unknown>> = Awaited<
+  ReturnType<F>
+>;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,3 @@
-import { tasksHandlers } from './tasks/handlers';
+import { tasksHandlers } from '@/features/tasks/mocks/handlers';
 
 export const handlers = [...tasksHandlers];

--- a/src/mocks/tasks/handlers.ts
+++ b/src/mocks/tasks/handlers.ts
@@ -1,7 +1,0 @@
-import { http } from 'msw';
-
-export const tasksHandlers = [
-  http.get('/api/tasks', () => {
-    console.log('/api/tasksのレスポンス');
-  }),
-];

--- a/src/routes/tasks/index.tsx
+++ b/src/routes/tasks/index.tsx
@@ -1,14 +1,30 @@
+import { useEffect, useState } from 'react';
+import { createTasksRepository } from '@/features/tasks/repository';
+import type { Task } from '@/features/tasks/types';
+import { apiClient } from '@/lib/api-client';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect } from 'react';
 
 export const Route = createFileRoute('/tasks/')({
   component: Tasks,
 });
 
 function Tasks() {
+  const [tasks, setTasks] = useState<Task[] | undefined>(undefined);
+
   useEffect(() => {
-    fetch('/api/tasks');
+    fetchTasks();
   }, []);
 
-  return <div>Tasks page</div>;
+  async function fetchTasks() {
+    const tasksRepository = createTasksRepository(apiClient);
+    const response = await tasksRepository.getAll();
+    setTasks(response);
+  }
+
+  return (
+    <div>
+      <h2>Tasks page</h2>
+      {tasks?.length ? tasks.map((task) => <pre>{task.id}</pre>) : null}
+    </div>
+  );
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,6 +15,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [TanStackRouterVite(), react()],
+  plugins: [TanStackRouterVite(), react(), tsconfigPaths()],
   test: {
     globals: true,
   },


### PR DESCRIPTION
## 作業概要

タスク取得用リポジトリの実装

## 作業内容

- タスク一覧を取得するリポジトリを追加。併せてテストも追加
- タスクのmockDataを生成するユーティリティ関数を追加

### その他
- ユーティリティな型を定義
- aliasが有効になるように設定ファイルを調整